### PR TITLE
Add mise support to base-ubuntu

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,8 +1,11 @@
 # Note: You can use any Debian/Ubuntu based image you want. 
-FROM mcr.microsoft.com/devcontainers/base:ubuntu-22.04
+FROM mcr.microsoft.com/devcontainers/base:ubuntu-24.04
 
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install --no-install-recommends \
     bash-completion \
+    pipx \
     # Clean up
     && apt-get autoremove -y && apt-get clean -y
+
+RUN pipx install pre-commit

--- a/src/base-ubuntu/.devcontainer/Dockerfile
+++ b/src/base-ubuntu/.devcontainer/Dockerfile
@@ -1,10 +1,8 @@
 # [Choice] Ubuntu version (use jammy on local arm64/Apple Silicon): jammy, focal
-ARG VARIANT="${VARIANT}"
-ARG BASE_IMAGE=buildpack-deps:${VARIANT}-curl
-FROM ${BASE_IMAGE}
+FROM mcr.microsoft.com/devcontainers/base:ubuntu-24.04
 
 ARG VARIANT="${VARIANT}"
-ARG BASE_IMAGE=buildpack-deps:${VARIANT}-curl
+ARG BASE_IMAGE=mcr.microsoft.com/devcontainers/base:ubuntu-24.04
 ENV BASE_IMAGE="${BASE_IMAGE}"
 
 LABEL dev.containers.features="common"

--- a/src/base-ubuntu/.devcontainer/Dockerfile
+++ b/src/base-ubuntu/.devcontainer/Dockerfile
@@ -19,9 +19,9 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     # Clean up
     && apt-get autoremove -y && apt-get clean -y
 
+# Install mise
 USER vscode
 
-# Install mise
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # ENV MISE_VERSION="..."
 ENV MISE_BIN_DIR="/home/vscode/.local/bin"

--- a/src/base-ubuntu/.devcontainer/Dockerfile
+++ b/src/base-ubuntu/.devcontainer/Dockerfile
@@ -14,5 +14,27 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install --no-install-recommends \
     make \
     bash-completion \
+    age \
+    ripgrep \
     # Clean up
     && apt-get autoremove -y && apt-get clean -y
+
+USER vscode
+
+# Install mise
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+# ENV MISE_VERSION="..."
+ENV MISE_BIN_DIR="/home/vscode/.local/bin"
+ENV MISE_INSTALL_PATH="/home/vscode/.local/bin/mise"
+ENV MISE_DATA_DIR="/home/vscode/.local/share/mise"
+ENV MISE_CONFIG_DIR="/home/vscode/.config/mise"
+ENV MISE_CACHE_DIR="/home/vscode/.cache/mise"
+
+ENV PATH="${MISE_BIN_DIR}:${MISE_DATA_DIR}/shims:${PATH}"
+
+RUN mkdir -p \
+    "${MISE_BIN_DIR}" \
+    "${MISE_DATA_DIR}" \
+    "${MISE_CONFIG_DIR}" \
+    "${MISE_CACHE_DIR}" \
+    && curl https://mise.run | sh

--- a/src/base-ubuntu/.devcontainer/devcontainer.json
+++ b/src/base-ubuntu/.devcontainer/devcontainer.json
@@ -9,7 +9,7 @@
     "features": {
         "ghcr.io/devcontainers/features/common-utils:2": {
             "installZsh": "true",
-            "username": "ubuntu",
+            "username": "vscode",
             "upgradePackages": "true"
         },
         "ghcr.io/devcontainers/features/git:1": {
@@ -18,6 +18,6 @@
         },
         "ghcr.io/devcontainers/features/python:1": {}
     },
-    "remoteUser": "ubuntu",
+    "remoteUser": "vscode",
     "updateRemoteUserUID": true
 }

--- a/src/base-ubuntu/test-project/test.sh
+++ b/src/base-ubuntu/test-project/test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 cd $(dirname "$0")
 
-source ../../../test/test-utils.sh  ubuntu
+source ../../../test/test-utils.sh  vscode
 
 # Run common tests
 checkCommon

--- a/src/base-ubuntu/test-project/test.sh
+++ b/src/base-ubuntu/test-project/test.sh
@@ -19,6 +19,14 @@ check "gitconfig-file-location" sh -c "ls /etc/gitconfig"
 check "gitconfig-contains-name" sh -c "cat /etc/gitconfig | grep 'name = devcontainers'"
 
 check "usr-local-etc-config-does-not-exist" test ! -f "/usr/local/etc/gitconfig"
+
+check "mise" mise --version
+check "mise-install-location" test -x "$HOME/.local/bin/mise"
+check "mise-on-path" sh -c '[ "$(command -v mise)" = "$HOME/.local/bin/mise" ]'
+check "mise-data-dir" test -d "$HOME/.local/share/mise"
+check "mise-config-dir" test -d "$HOME/.config/mise"
+check "mise-cache-dir" test -d "$HOME/.cache/mise"
+
 checkPythonExtension
 
 # Report result

--- a/test/test-utils.sh
+++ b/test/test-utils.sh
@@ -162,6 +162,8 @@ checkCommon()
         libstdc++6 \
         zlib1g \
         locales \
+        age \
+        ripgrep \
         sudo"
 
     # Actual tests


### PR DESCRIPTION
## Summary
- install mise in the base-ubuntu image and add coverage for it in the base-ubuntu test project
- switch base-ubuntu to the devcontainers Ubuntu 24.04 base image and keep the runtime user aligned with the default `vscode` user
- add `pre-commit` to the workspace devcontainer tooling

## Testing
- devcontainer build --workspace-folder src/base-ubuntu --image-name base-ubuntu:vscode-check
- ./test/test_build.sh base-ubuntu vscode-check