### PR TITLE
fix(base-ubuntu): restore root as default image user

### DIFF
--- a/src/base-ubuntu/.devcontainer/Dockerfile
+++ b/src/base-ubuntu/.devcontainer/Dockerfile
@@ -37,3 +37,5 @@ RUN mkdir -p \
     "${MISE_CONFIG_DIR}" \
     "${MISE_CACHE_DIR}" \
     && curl https://mise.run | sh
+
+USER root

--- a/src/base-ubuntu/.devcontainer/Dockerfile
+++ b/src/base-ubuntu/.devcontainer/Dockerfile
@@ -37,3 +37,6 @@ RUN mkdir -p \
     "${MISE_CONFIG_DIR}" \
     "${MISE_CACHE_DIR}" \
     && curl https://mise.run | sh
+
+# hadolint ignore=DL3002
+USER root

--- a/src/base-ubuntu/.devcontainer/Dockerfile
+++ b/src/base-ubuntu/.devcontainer/Dockerfile
@@ -37,5 +37,3 @@ RUN mkdir -p \
     "${MISE_CONFIG_DIR}" \
     "${MISE_CACHE_DIR}" \
     && curl https://mise.run | sh
-
-USER root

--- a/src/base-ubuntu/.devcontainer/devcontainer.json
+++ b/src/base-ubuntu/.devcontainer/devcontainer.json
@@ -18,6 +18,7 @@
         },
         "ghcr.io/devcontainers/features/python:1": {}
     },
+    "containerUser": "root",
     "remoteUser": "vscode",
     "updateRemoteUserUID": true
 }

--- a/src/base-ubuntu/.devcontainer/devcontainer.json
+++ b/src/base-ubuntu/.devcontainer/devcontainer.json
@@ -18,7 +18,6 @@
         },
         "ghcr.io/devcontainers/features/python:1": {}
     },
-    "containerUser": "root",
     "remoteUser": "vscode",
     "updateRemoteUserUID": true
 }


### PR DESCRIPTION
## Summary
- set the final Docker image user back to root after installing mise as vscode
- keep devcontainer runtime on vscode via the existing remoteUser setting

## Validation
- reviewed the single-file diff
- attempted `./test/pre_build.sh base-ubuntu review-check` but the build could not reach mcr.microsoft.com in this environment
